### PR TITLE
Wrap the response in an error object

### DIFF
--- a/clojure/src/wombats.clj
+++ b/clojure/src/wombats.clj
@@ -7,8 +7,11 @@
   [event time-left]
   ;; Call the passed in code with the appropriate args
   (try
-    ((load-string (:code event)) (:state event) time-left)
-    (catch Exception e)))
+    {:response ((load-string (:code event)) (:state event) time-left)
+     :error nil}
+    (catch Exception e
+      {:response nil
+       :error e})))
 
 (deflambdafn wombats.Handler
   [in out ctx]


### PR DESCRIPTION
@dehli I added errors to the response payload to support debugging from the client