### PR TITLE
Clojure security

### DIFF
--- a/clojure/src/wombats.clj
+++ b/clojure/src/wombats.clj
@@ -3,6 +3,27 @@
             [cheshire.core :as cheshire]
             [clojure.java.io :as io]))
 
+;; These are the variables we clear
+(defonce envs ["AWS_ACCESS_KEY"
+               "AWS_ACCESS_KEY_ID"
+               "AWS_SECRET_ACCESS_KEY" 
+               "AWS_SECRET_KEY"
+               "AWS_SECURITY_TOKEN" 
+               "AWS_SESSION_TOKEN"])
+
+(defn- clear-envs
+  "Clears environment variables so they're not accessible"
+  []
+  (let [env (System/getenv)
+        cl (.getClass env)
+        field (.getDeclaredField cl "m")]
+
+    (.setAccessible field true)
+
+    (let [writable-env (.get field env)]
+      (doseq [env envs]
+        (.put writable-env env "")))))
+
 (defn handle-event
   [event time-left]
   ;; Call the passed in code with the appropriate args
@@ -18,7 +39,8 @@
                :stackTrace (map str (.getStackTrace e))}})))
 
 (deflambdafn wombats.Handler
-  [in out ctx]
+  [in out ctx]  
+  (clear-envs)
   (let [time-left (fn [] (.getRemainingTimeInMillis ctx))
         event (cheshire/parse-stream (io/reader in) true)
         res (handle-event event time-left)]

--- a/python/handler.py
+++ b/python/handler.py
@@ -2,12 +2,14 @@
 import sys, traceback
 import os
 
+envs = ['AWS_ACCESS_KEY', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', \
+        'AWS_SECRET_KEY', 'AWS_SECURITY_TOKEN', 'AWS_SESSION_TOKEN']
+
 def handle_event(event, time_left):
     """ Handles the execution of a Wombat's code"""
 
     # Remove sensitive environment variables
-    keys = ['AWS_SESSION_TOKEN', 'AWS_SECURITY_TOKEN', 'AWS_SECRET_ACCESS_KEY', 'AWS_ACCESS_KEY_ID']
-    for key in keys:
+    for key in envs:
         if key in os.environ:
             del os.environ[key]
 


### PR DESCRIPTION
# PR for Clojure Security.

## Implementation Notes:
- Hide certain environment variables from Clojure code.
- Made it so Python hides the same variables.

I didn't update the `CHANGELOG` since Lambda isn't on a release cycle yet.